### PR TITLE
EPIC-03 / US-08 - Add PostgreSQL persistence for tasks using SQLAlchemy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 # Application
 # ----------------------------------------
 APP_NAME=Task API
-APP_ENV=dev/quality/prod
+# Possible values: dev, quality, prod
+APP_ENV=dev
 
 # ----------------------------------------
 # Database - shared
@@ -15,13 +16,13 @@ DB_NAME=task_api_dev
 # Database - app user
 # ----------------------------------------
 DB_APP_USER=task_api_app_dev
-DB_APP_PASSWORD=xxxxxx
+DB_APP_PASSWORD=your_app_password
 
 # ----------------------------------------
 # Database - migration user
 # ----------------------------------------
 DB_MIGRATION_USER=task_api_migrator_dev
-DB_MIGRATION_PASSWORD=yyyyyy
+DB_MIGRATION_PASSWORD=your_migration_password
 
 # Temporary bootstrap flag for local development.
 # Later, with migrations, this should no longer control create_all().

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# ----------------------------------------
+# Application
+# ----------------------------------------
+APP_NAME=Task API
+APP_ENV=dev/quality/prod
+
+# ----------------------------------------
+# Database - shared
+# ----------------------------------------
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=task_api_dev
+
+# ----------------------------------------
+# Database - app user
+# ----------------------------------------
+DB_APP_USER=task_api_app_dev
+DB_APP_PASSWORD=xxxxxx
+
+# ----------------------------------------
+# Database - migration user
+# ----------------------------------------
+DB_MIGRATION_USER=task_api_migrator_dev
+DB_MIGRATION_PASSWORD=yyyyyy
+
+# Temporary bootstrap flag for local development.
+# Later, with migrations, this should no longer control create_all().
+DB_BOOTSTRAP=true

--- a/app/application/unit_of_work.py
+++ b/app/application/unit_of_work.py
@@ -1,0 +1,6 @@
+from typing import Protocol
+
+
+class UnitOfWork(Protocol):
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -1,0 +1,52 @@
+from urllib.parse import quote_plus
+
+from pydantic import computed_field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore",
+    )
+
+    # Application
+    app_name: str = "Task API"
+    app_env: str = "dev"
+
+    # Database - shared
+    db_host: str
+    db_port: int
+    db_name: str
+
+    # Database - app user
+    db_app_user: str
+    db_app_password: str
+
+    # Database - migration user
+    db_migration_user: str
+    db_migration_password: str
+
+    # Dev bootstrap
+    db_bootstrap: bool = False
+
+    @computed_field
+    @property
+    def database_url(self) -> str:
+        password = quote_plus(self.db_app_password)
+        return (
+            f"postgresql+psycopg://{self.db_app_user}:{password}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+        )
+
+    @computed_field
+    @property
+    def database_migration_url(self) -> str:
+        password = quote_plus(self.db_migration_password)
+        return (
+            f"postgresql+psycopg://{self.db_migration_user}:{password}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+        )
+
+    
+settings = Settings()

--- a/app/infrastructure/db/base.py
+++ b/app/infrastructure/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy ORM models."""

--- a/app/infrastructure/db/bootstrap.py
+++ b/app/infrastructure/db/bootstrap.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+
+from app.core.config.settings import settings
+from app.infrastructure.db.base import Base
+from app.modules.tasks.infrastructure.task_model import TaskModel  # noqa: F401
+
+
+def bootstrap_database() -> None:
+    """Create missing database tables using the migration database user."""
+    engine = create_engine(
+        settings.database_migration_url,
+        echo=False,
+        future=True,
+        pool_pre_ping=True,
+    )
+    Base.metadata.create_all(bind=engine)

--- a/app/infrastructure/db/session_factory.py
+++ b/app/infrastructure/db/session_factory.py
@@ -1,0 +1,31 @@
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.config.settings import settings
+
+
+engine = create_engine(
+    settings.database_url,
+    echo=False,
+    future=True,
+    pool_pre_ping=True,
+)
+
+SessionFactory = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+    class_=Session,
+)
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    """Provide a database session for one request."""
+    session = SessionFactory()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/app/infrastructure/db/sqlalchemy_unit_of_work.py
+++ b/app/infrastructure/db/sqlalchemy_unit_of_work.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+
+from app.application.unit_of_work import UnitOfWork
+
+
+class SqlAlchemyUnitOfWork(UnitOfWork):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def commit(self) -> None:
+        self._session.commit()
+
+    def rollback(self) -> None:
+        self._session.rollback()

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,11 @@
-# app/main.py
-
 from fastapi import FastAPI
 
 from app.modules.tasks.api.task_router import router as tasks_router
+from app.core.config.settings import settings
 from app.api.health_router import router as health_router
 from app.modules.tasks.api.exception_handlers import register_exception_handlers
 
-app = FastAPI()
+app = FastAPI(title=settings.app_name)
 
 register_exception_handlers(app)
 

--- a/app/modules/tasks/api/dependencies.py
+++ b/app/modules/tasks/api/dependencies.py
@@ -1,20 +1,24 @@
-# app/infrastructure/dependencies.py
+from fastapi import Depends
+from sqlalchemy.orm import Session
 
+from app.infrastructure.db.session_factory import get_db_session
 from app.modules.tasks.application.task_repository import TaskRepository
 from app.modules.tasks.application.task_service import TaskService
-from app.modules.tasks.infrastructure.in_memory_task_repository import InMemoryTaskRepository
+from app.application.unit_of_work import UnitOfWork
+from app.modules.tasks.infrastructure.sqlalchemy_task_repository import SqlAlchemyTaskRepository
+from app.infrastructure.db.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
 
-# Shared in-memory repository so application state survives across requests.
-_task_repository = InMemoryTaskRepository()
+def get_task_repository(session: Session = Depends(get_db_session)) -> TaskRepository:
+    return SqlAlchemyTaskRepository(session=session)
 
 
-def get_task_repository() -> TaskRepository:
-    """Return the repository instance used by the application."""
-    return _task_repository
+def get_unit_of_work(session: Session = Depends(get_db_session)) -> UnitOfWork:
+    return SqlAlchemyUnitOfWork(session=session)
 
 
-def get_task_service() -> TaskService:
-    """Return the task service instance used by the API layer."""
-    repository = get_task_repository()
-    return TaskService(repository=repository)
+def get_task_service(
+    repository: TaskRepository = Depends(get_task_repository),
+    uow: UnitOfWork = Depends(get_unit_of_work),
+) -> TaskService:
+    return TaskService(repository=repository, uow=uow)

--- a/app/modules/tasks/application/task_service.py
+++ b/app/modules/tasks/application/task_service.py
@@ -1,9 +1,9 @@
-from datetime import UTC, datetime, date
+from datetime import UTC, datetime
 
 from app.modules.tasks.application.task_dtos import TaskInput, PatchTaskInput
 from app.modules.tasks.application.task_repository import TaskRepository
+from app.application.unit_of_work import UnitOfWork
 from app.modules.tasks.domain.task import Task
-from app.modules.tasks.domain.task_status import TaskStatus
 
 
 class TaskNotFoundError(Exception):
@@ -11,14 +11,15 @@ class TaskNotFoundError(Exception):
 
 
 class TaskService:
-    def __init__(self, repository: TaskRepository) -> None:
+    def __init__(self, repository: TaskRepository, uow: UnitOfWork) -> None:
         self._repository = repository
+        self._uow = uow
 
     def _current_timestamp(self) -> datetime:
         """Return the current UTC timestamp without microseconds."""
         return datetime.now(UTC).replace(microsecond=0)
 
-    def _apply_update(self, task: Task, task_input: TaskInput) -> Task:
+    def _apply_update(self, task: Task, task_input: TaskInput) -> tuple[Task, bool]:
         """Apply a full update to an existing task and persist it if changed."""
         changed = task.update(
             title=task_input.title,
@@ -28,11 +29,13 @@ class TaskService:
             is_blocked=task_input.is_blocked,
         )
 
-        if changed:
-            task.mark_updated(self._current_timestamp())
-            return self._repository.save_task(task)
 
-        return task
+        if not changed:
+            return task, False
+
+        task.mark_updated(self._current_timestamp())
+        persisted_task = self._repository.save_task(task)
+        return persisted_task, True
 
     def list_tasks(self) -> list[Task]:
         """Return all tasks currently stored."""
@@ -41,16 +44,23 @@ class TaskService:
 
     def create_task(self, task: TaskInput) -> Task:
         """Create a new task through the repository contract."""
-        task = Task.create(
-            title=task.title,
-            description=task.description,
-            status=task.status,
-            due_date=task.due_date,
-            is_blocked=task.is_blocked,
-            created_at=self._current_timestamp()
-        )
+        try:
+            task = Task.create(
+                title=task.title,
+                description=task.description,
+                status=task.status,
+                due_date=task.due_date,
+                is_blocked=task.is_blocked,
+                created_at=self._current_timestamp()
+            )
 
-        return self._repository.create_task(task)
+            created_task = self._repository.create_task(task)
+            self._uow.commit()
+            return created_task
+
+        except Exception:
+            self._uow.rollback()
+            raise
 
     def get_task(self, task_id: int) -> Task:
         """Return a task by id or raise TaskNotFoundError if it does not exist."""
@@ -63,25 +73,51 @@ class TaskService:
 
     def update_task(self, task_id: int, task_input: TaskInput) -> Task:
         """Fully replace task data using the provided application input."""
-        current_task = self.get_task(task_id)
+        try:
+            current_task = self.get_task(task_id)
+            updated_task, changed = self._apply_update(current_task, task_input)
 
-        return self._apply_update(current_task, task_input)
+            if changed:
+                self._uow.commit()
+
+            return updated_task
+
+        except Exception:
+            self._uow.rollback()
+            raise
 
     def patch_task(self, task_id: int, task_input: PatchTaskInput) -> Task:
         """Partially update task data using the provided application input."""
-        current_task = self.get_task(task_id)
+        try:
+            current_task = self.get_task(task_id)
 
-        task_input = TaskInput(
-            title=task_input.title if task_input.title_provided else current_task.title,
-            description=task_input.description if task_input.description_provided else current_task.description,
-            status=task_input.status if task_input.status_provided else current_task.status,
-            due_date=task_input.due_date if task_input.due_date_provided else current_task.due_date,
-            is_blocked=task_input.is_blocked if task_input.is_blocked_provided else current_task.is_blocked,
-        )
+            full_input = TaskInput(
+                title=task_input.title if task_input.title_provided else current_task.title,
+                description=task_input.description if task_input.description_provided else current_task.description,
+                status=task_input.status if task_input.status_provided else current_task.status,
+                due_date=task_input.due_date if task_input.due_date_provided else current_task.due_date,
+                is_blocked=task_input.is_blocked if task_input.is_blocked_provided else current_task.is_blocked,
+            )
 
-        return self._apply_update(current_task, task_input)
+            updated_task, changed = self._apply_update(current_task, full_input)
+
+            if changed:
+                self._uow.commit()
+
+            return updated_task
+
+        except Exception:
+            self._uow.rollback()
+            raise
+
 
     def delete_task(self, task_id: int) -> None:
         """Delete a task by id or raise TaskNotFoundError if it does not exist."""
-        self.get_task(task_id)
-        self._repository.delete_task(task_id)
+        try:
+            self.get_task(task_id)
+            self._repository.delete_task(task_id)
+            self._uow.commit()
+
+        except Exception:
+            self._uow.rollback()
+            raise

--- a/app/modules/tasks/infrastructure/in_memory_task_repository.py
+++ b/app/modules/tasks/infrastructure/in_memory_task_repository.py
@@ -1,6 +1,6 @@
 # app/infrastructure/repositories/in_memory_task_repository.py
 
-from app.modules.tasks.application.task_repository import Task, TaskRepository
+from app.modules.tasks.application.task_repository import TaskRepository
 from app.modules.tasks.domain.task import Task
 
 
@@ -25,6 +25,8 @@ class InMemoryTaskRepository(TaskRepository):
 
     def save_task(self, task: Task) -> Task:
         """Store or replace a task in memory and return it."""
+        if task.id is None:
+            raise ValueError("Cannot save a task without an id")
         self._tasks[task.id] = task
         return task
 

--- a/app/modules/tasks/infrastructure/sqlalchemy_task_repository.py
+++ b/app/modules/tasks/infrastructure/sqlalchemy_task_repository.py
@@ -1,0 +1,83 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.modules.tasks.application.task_repository import TaskRepository
+from app.modules.tasks.domain.task import Task
+from app.modules.tasks.domain.task_status import TaskStatus
+from app.modules.tasks.infrastructure.task_model import TaskModel
+
+
+class SqlAlchemyTaskRepository(TaskRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def list_tasks(self) -> list[Task]:
+        stmt = select(TaskModel).order_by(TaskModel.id)
+        models = self._session.scalars(stmt).all()
+        return [self._to_domain(model) for model in models]
+
+    def get_task(self, task_id: int) -> Task | None:
+        model = self._session.get(TaskModel, task_id)
+
+        if model is None:
+            return None
+
+        return self._to_domain(model)
+
+    def create_task(self, task: Task) -> Task:
+        model = self._to_model(task)
+
+        self._session.add(model)
+        self._session.flush()
+
+        return self._to_domain(model)
+
+    def save_task(self, task: Task) -> Task:
+        if task.id is None:
+            raise ValueError("Cannot save a task without an id")
+
+        model = self._session.get(TaskModel, task.id)
+        if model is None:
+            raise ValueError(f"Task with id {task.id} was not found")
+
+        self._apply_domain_to_model(task, model)
+        self._session.flush()
+        
+        return self._to_domain(model)
+
+    def delete_task(self, task_id: int) -> None:
+        model = self._session.get(TaskModel, task_id)
+
+        if model is not None:
+            self._session.delete(model)
+
+    def _to_domain(self, model: TaskModel) -> Task:
+        return Task(
+            id=model.id,
+            title=model.title,
+            description=model.description,
+            status=TaskStatus(model.status),
+            due_date=model.due_date,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+            is_blocked=model.is_blocked,
+        )
+
+    def _to_model(self, task: Task) -> TaskModel:
+        return TaskModel(
+            title=task.title,
+            description=task.description,
+            status=task.status.value,
+            due_date=task.due_date,
+            created_at=task.created_at,
+            updated_at=task.updated_at,
+            is_blocked=task.is_blocked,
+        )
+
+    def _apply_domain_to_model(self, task: Task, model: TaskModel) -> None:
+        model.title = task.title
+        model.description = task.description
+        model.status = task.status.value
+        model.due_date = task.due_date
+        model.updated_at = task.updated_at
+        model.is_blocked = task.is_blocked

--- a/app/modules/tasks/infrastructure/task_model.py
+++ b/app/modules/tasks/infrastructure/task_model.py
@@ -1,0 +1,19 @@
+from datetime import date, datetime
+
+from sqlalchemy import Boolean, Date, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.infrastructure.db.base import Base
+
+
+class TaskModel(Base):
+    __tablename__ = "tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    is_blocked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -13,4 +13,17 @@ def bootstrap_database() -> None:
         future=True,
         pool_pre_ping=True,
     )
-    Base.metadata.create_all(bind=engine)
+
+    try:
+        Base.metadata.create_all(bind=engine)
+    finally:
+        engine.dispose()
+
+
+def main() -> None:
+    """Run the manual database bootstrap."""
+    bootstrap_database()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,11 +9,16 @@ from app.modules.tasks.application.task_service import TaskService
 from app.modules.tasks.api.task_schemas import TaskResponse
 from app.modules.tasks.api.dependencies import get_task_service
 
+class FakeUnitOfWork:
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
 
 # ----------------------------------------
 # Test client
 # ----------------------------------------
-
 @pytest.fixture
 def client():
     """
@@ -22,21 +27,19 @@ def client():
     This keeps API integration tests isolated and aligned with the current
     router -> service -> repository architecture.
     """
-    # Arrange
     test_repository = InMemoryTaskRepository()
-    test_service = TaskService(repository=test_repository)
+    test_uow = FakeUnitOfWork()
+    test_service = TaskService(repository=test_repository, uow=test_uow)
 
     def override_get_task_service() -> TaskService:
         return test_service
 
     app.dependency_overrides[get_task_service] = override_get_task_service
 
-    # Act
     try:
         with TestClient(app) as client:
             yield client
     finally:
-        # Cleanup
         app.dependency_overrides.clear()
 
 
@@ -44,24 +47,22 @@ def client():
 # Task factory
 # ----------------------------------------
 
+
 @pytest.fixture
 def create_task(client: TestClient):
     """
     Provide a helper to create tasks through the HTTP API.
     """
-
     def _create_task(**overrides):
-
         payload = {
-            "title": "Test task", 
-            "description": "testing", 
-            "due_date": None, 
-            "status": "pending", 
-            "is_blocked": "false"
-            }
+            "title": "Test task",
+            "description": "testing",
+            "due_date": None,
+            "status": "pending",
+            "is_blocked": False,
+        }
 
         payload.update(overrides)
-
         return client.post("/tasks", json=payload)
 
     return _create_task

--- a/tests/unit/tasks/application/test_task_service.py
+++ b/tests/unit/tasks/application/test_task_service.py
@@ -1,34 +1,32 @@
-# tests/unit/services/test_task_service.py
-
 from datetime import date, datetime
 from unittest.mock import Mock
 
 import pytest
 
+from app.application.unit_of_work import UnitOfWork
 from app.modules.tasks.domain.task import Task
 from app.modules.tasks.domain.task_status import TaskStatus
 from app.modules.tasks.domain.task_errors import InvalidTaskDueDateError
 from app.modules.tasks.application.task_repository import TaskRepository
 from app.modules.tasks.application.task_service import TaskNotFoundError, TaskService
-from tests.factories.task import build_new_task,build_task, future_date, future_date
+from tests.factories.task import build_new_task, build_task, future_date
 from app.modules.tasks.application.task_dtos import TaskInput, PatchTaskInput
 
 valid_due_date = future_date()
 
 @pytest.fixture
 def repository() -> Mock:
-    """
-    Return a mock TaskRepository for each test.
-    """
     return Mock(spec=TaskRepository)
 
 
 @pytest.fixture
-def task_service(repository: Mock) -> TaskService:
-    """
-    Return a TaskService instance with a mocked repository.
-    """
-    return TaskService(repository=repository)
+def uow() -> Mock:
+    return Mock(spec=UnitOfWork)
+
+
+@pytest.fixture
+def task_service(repository: Mock, uow: Mock) -> TaskService:
+    return TaskService(repository=repository, uow=uow)
 
 
 def save_task_side_effect(task: Task) -> Task:
@@ -68,39 +66,6 @@ def test_get_task_raises_when_repository_returns_none(task_service: TaskService,
     repository.get_task.assert_called_once_with(999)
 
 # ----------------------------------------
-# delete_task
-# ----------------------------------------
-
-def test_delete_task_calls_repository_delete_when_task_exists(task_service: TaskService, repository: Mock):
-    """
-    delete_task should call repository.delete_task when the task exists.
-    """
-    # Arrange
-    existing_task = build_new_task( title="Task to delete")
-    repository.get_task.return_value = existing_task
-
-    # Act
-    task_service.delete_task(1)
-
-    # Assert
-    repository.get_task.assert_called_once_with(1)
-    repository.delete_task.assert_called_once_with(1)
-
-def test_delete_task_raises_when_repository_returns_none(task_service: TaskService, repository: Mock):
-    """
-    delete_task should raise TaskNotFoundError when the repository does not find the task.
-    """
-    # Arrange
-    repository.get_task.return_value = None
-
-    # Act / Assert
-    with pytest.raises(TaskNotFoundError, match="Task not found"):
-        task_service.delete_task(999)
-
-    repository.get_task.assert_called_once_with(999)
-    repository.delete_task.assert_not_called()
-
-# ----------------------------------------
 # list_tasks
 # ----------------------------------------
 
@@ -123,12 +88,14 @@ def test_list_tasks_returns_tasks_from_repository(task_service: TaskService, rep
 # create_task
 # ----------------------------------------
 
-def test_create_task_delegates_creation_to_repository_with_default_status(
+def test_create_task_delegates_creation_to_repository_with_default_status_and_commits(
     task_service: TaskService,
     repository: Mock,
+    uow: Mock,
 ) -> None:
     """
-    create_task should build TaskInput and delegate creation to the repository.
+    create_task should build a domain Task, delegate creation to the repository,
+    and commit the transaction on success.
     """
     # Arrange
     task_input = TaskInput(
@@ -136,10 +103,9 @@ def test_create_task_delegates_creation_to_repository_with_default_status(
         description="testing",
         due_date=None,
         is_blocked=False,
-        status=TaskStatus.PENDING
+        status=TaskStatus.PENDING,
     )
     created_task = build_new_task(
-        
         title="My first task",
         description="testing",
         due_date=None,
@@ -153,6 +119,8 @@ def test_create_task_delegates_creation_to_repository_with_default_status(
     # Assert
     assert result == created_task
     repository.create_task.assert_called_once()
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
     create_data = repository.create_task.call_args.args[0]
     assert isinstance(create_data, Task)
@@ -164,12 +132,13 @@ def test_create_task_delegates_creation_to_repository_with_default_status(
     assert isinstance(create_data.created_at, datetime)
 
 
-def test_create_task_passes_due_date_to_repository(
+def test_create_task_passes_due_date_to_repository_and_commits(
     task_service: TaskService,
     repository: Mock,
+    uow: Mock,
 ) -> None:
     """
-    create_task should pass due_date to the repository when provided.
+    create_task should pass due_date to the repository and commit on success.
     """
     # Arrange
     task_input = TaskInput(
@@ -177,10 +146,9 @@ def test_create_task_passes_due_date_to_repository(
         description="testing",
         due_date=valid_due_date,
         is_blocked=False,
-        status=TaskStatus.PENDING
+        status=TaskStatus.PENDING,
     )
     created_task = build_new_task(
-        
         title="Task with due date",
         description="testing",
         due_date=valid_due_date,
@@ -194,6 +162,8 @@ def test_create_task_passes_due_date_to_repository(
     # Assert
     assert result == created_task
     repository.create_task.assert_called_once()
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
     create_data = repository.create_task.call_args.args[0]
     assert isinstance(create_data, Task)
@@ -205,12 +175,13 @@ def test_create_task_passes_due_date_to_repository(
     assert isinstance(create_data.created_at, datetime)
 
 
-def test_create_task_passes_is_blocked_to_repository(
+def test_create_task_passes_is_blocked_to_repository_and_commits(
     task_service: TaskService,
     repository: Mock,
+    uow: Mock,
 ) -> None:
     """
-    create_task should pass is_blocked to the repository when provided.
+    create_task should pass is_blocked to the repository and commit on success.
     """
     # Arrange
     task_input = TaskInput(
@@ -218,10 +189,9 @@ def test_create_task_passes_is_blocked_to_repository(
         description="testing",
         due_date=None,
         is_blocked=True,
-        status=TaskStatus.PENDING
+        status=TaskStatus.PENDING,
     )
     created_task = build_new_task(
-        
         title="Blocked task",
         description="testing",
         due_date=None,
@@ -235,6 +205,8 @@ def test_create_task_passes_is_blocked_to_repository(
     # Assert
     assert result == created_task
     repository.create_task.assert_called_once()
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
     create_data = repository.create_task.call_args.args[0]
     assert isinstance(create_data, Task)
@@ -245,17 +217,48 @@ def test_create_task_passes_is_blocked_to_repository(
     assert create_data.is_blocked is True
     assert isinstance(create_data.created_at, datetime)
 
+
+def test_create_task_rolls_back_when_repository_create_fails(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    create_task should roll back and re-raise when repository.create_task fails.
+    """
+    # Arrange
+    task_input = TaskInput(
+        title="My first task",
+        description="testing",
+        due_date=None,
+        is_blocked=False,
+        status=TaskStatus.PENDING,
+    )
+    repository.create_task.side_effect = RuntimeError("DB error")
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="DB error"):
+        task_service.create_task(task_input)
+
+    repository.create_task.assert_called_once()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()
+
 # ----------------------------------------
 # update_task
 # ----------------------------------------
 
-def test_update_task_replaces_task_data_and_saves_it(task_service: TaskService, repository: Mock):
+def test_update_task_replaces_task_data_saves_it_and_commits(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
     """
-    update_task should fully replace task fields and save the updated task.
+    update_task should fully replace task fields, save the updated task,
+    and commit the transaction when a real change happens.
     """
     # Arrange
     existing_task = build_task(title="Original title", description="original", due_date=None)
-
     repository.get_task.return_value = existing_task
 
     task_update = TaskInput(
@@ -263,7 +266,7 @@ def test_update_task_replaces_task_data_and_saves_it(task_service: TaskService, 
         description="updated",
         status=TaskStatus.IN_PROGRESS,
         due_date=valid_due_date,
-        is_blocked=True
+        is_blocked=True,
     )
 
     repository.save_task.side_effect = save_task_side_effect
@@ -283,14 +286,27 @@ def test_update_task_replaces_task_data_and_saves_it(task_service: TaskService, 
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_called_once_with(existing_task)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
-def test_update_task_raises_when_repository_returns_none(task_service: TaskService, repository: Mock):
+
+def test_update_task_raises_and_rolls_back_when_repository_returns_none(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
     """
-    update_task should raise TaskNotFoundError when the repository does not find the task.
+    update_task should raise TaskNotFoundError and roll back when the repository does not find the task.
     """
     # Arrange
     repository.get_task.return_value = None
-    task_update = TaskInput(title="Updated title", description="updated", status=TaskStatus.IN_PROGRESS, due_date=date(2026, 3, 20), is_blocked=False)
+    task_update = TaskInput(
+        title="Updated title",
+        description="updated",
+        status=TaskStatus.IN_PROGRESS,
+        due_date=date(2026, 3, 20),
+        is_blocked=False,
+    )
 
     # Act / Assert
     with pytest.raises(TaskNotFoundError, match="Task not found"):
@@ -298,10 +314,18 @@ def test_update_task_raises_when_repository_returns_none(task_service: TaskServi
 
     repository.get_task.assert_called_once_with(999)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()
 
-def test_update_task_saves_pending_state_with_nullable_fields(task_service: TaskService, repository: Mock):
+
+def test_update_task_saves_pending_state_with_nullable_fields_and_commits(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
     """
-    update_task should allow description and due_date to be set to None.
+    update_task should allow description and due_date to be set to None
+    and commit when a real change happens.
     """
     # Arrange
     existing_task = build_task(title="Original title", description="original")
@@ -313,7 +337,7 @@ def test_update_task_saves_pending_state_with_nullable_fields(task_service: Task
         description=None,
         status=TaskStatus.PENDING,
         due_date=None,
-        is_blocked=False
+        is_blocked=False,
     )
 
     # Act
@@ -330,18 +354,24 @@ def test_update_task_saves_pending_state_with_nullable_fields(task_service: Task
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_called_once_with(existing_task)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
-def test_update_task_does_not_save_when_no_real_changes(task_service: TaskService, repository: Mock):
+
+def test_update_task_does_not_save_or_commit_when_no_real_changes(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
     """
-    update_task should not save the task when the payload does not change any field.
+    update_task should not save or commit when the payload does not change any field.
     """
     # Arrange
     existing_task = build_new_task(
-        
         title="Original title",
         description="original",
         status=TaskStatus.IN_PROGRESS,
-        due_date=valid_due_date
+        due_date=valid_due_date,
     )
     repository.get_task.return_value = existing_task
 
@@ -350,7 +380,7 @@ def test_update_task_does_not_save_when_no_real_changes(task_service: TaskServic
         description="original",
         status=TaskStatus.IN_PROGRESS,
         due_date=valid_due_date,
-        is_blocked=False
+        is_blocked=False,
     )
 
     # Act
@@ -362,10 +392,18 @@ def test_update_task_does_not_save_when_no_real_changes(task_service: TaskServic
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_not_called()
 
-def test_update_task_updates_is_blocked_when_provided(task_service: TaskService, repository: Mock):
+
+def test_update_task_updates_is_blocked_when_provided_and_commits(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
     """
-    update_task should replace is_blocked when provided in the PUT payload.
+    update_task should replace is_blocked when provided in the PUT payload
+    and commit when a real change happens.
     """
     # Arrange
     existing_task = build_new_task(status=TaskStatus.PENDING, due_date=None)
@@ -377,7 +415,7 @@ def test_update_task_updates_is_blocked_when_provided(task_service: TaskService,
         description=existing_task.description,
         status=TaskStatus.PENDING,
         due_date=None,
-        is_blocked=True
+        is_blocked=True,
     )
 
     # Act
@@ -386,11 +424,24 @@ def test_update_task_updates_is_blocked_when_provided(task_service: TaskService,
     # Assert
     assert result.is_blocked is True
     assert result.updated_at is not None
+
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_called_once_with(existing_task)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
-def test_update_task_propagates_domain_error_and_does_not_save_when_final_state_is_invalid(task_service: TaskService, repository: Mock) -> None:
-    existing_task = build_new_task( status=TaskStatus.PENDING, due_date=None)
+
+def test_update_task_propagates_domain_error_rolls_back_and_does_not_save_when_final_state_is_invalid(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    update_task should propagate domain validation errors, avoid saving,
+    and roll back the transaction.
+    """
+    # Arrange
+    existing_task = build_new_task(status=TaskStatus.PENDING, due_date=None)
     repository.get_task.return_value = existing_task
 
     task_update = TaskInput(
@@ -398,22 +449,33 @@ def test_update_task_propagates_domain_error_and_does_not_save_when_final_state_
         description=existing_task.description,
         status=TaskStatus.IN_PROGRESS,
         due_date=None,
-        is_blocked=False
+        is_blocked=False,
     )
 
+    # Act / Assert
     with pytest.raises(InvalidTaskDueDateError, match="Due date is required for IN PROGRESS tasks"):
         task_service.update_task(1, task_update)
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()
 
 # ----------------------------------------
 # patch_task
 # ----------------------------------------
 
-def test_patch_task_updates_only_provided_fields(task_service: TaskService, repository: Mock) -> None:
+def test_patch_task_updates_only_provided_fields_saves_and_commits(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    patch_task should update only the provided fields, save the task,
+    and commit when a real change happens.
+    """
+    # Arrange
     existing_task = build_new_task(
-        
         title="Original title",
         description="original",
         status=TaskStatus.PENDING,
@@ -428,8 +490,10 @@ def test_patch_task_updates_only_provided_fields(task_service: TaskService, repo
         description_provided=True,
     )
 
+    # Act
     result = task_service.patch_task(1, task_patch)
 
+    # Assert
     assert result.title == "Original title"
     assert result.description == "updated description"
     assert result.status == TaskStatus.PENDING
@@ -439,10 +503,21 @@ def test_patch_task_updates_only_provided_fields(task_service: TaskService, repo
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_called_once_with(existing_task)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
-def test_patch_task_allows_description_to_be_cleared(task_service: TaskService, repository: Mock) -> None:
+
+def test_patch_task_allows_description_to_be_cleared_saves_and_commits(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    patch_task should allow clearing description, save the task,
+    and commit when a real change happens.
+    """
+    # Arrange
     existing_task = build_new_task(
-        
         description="original",
         due_date=valid_due_date,
     )
@@ -454,17 +529,29 @@ def test_patch_task_allows_description_to_be_cleared(task_service: TaskService, 
         description_provided=True,
     )
 
+    # Act
     result = task_service.patch_task(1, task_patch)
 
+    # Assert
     assert result.description is None
     assert result.updated_at is not None
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_called_once_with(existing_task)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
 
-def test_patch_task_does_not_save_when_patch_does_not_change_state(task_service: TaskService, repository: Mock) -> None:
+
+def test_patch_task_does_not_save_or_commit_when_patch_does_not_change_state(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    patch_task should not save or commit when the final state is unchanged.
+    """
+    # Arrange
     existing_task = build_new_task(
-        
         title="Original title",
         description="original",
         status=TaskStatus.PENDING,
@@ -478,15 +565,28 @@ def test_patch_task_does_not_save_when_patch_does_not_change_state(task_service:
         title_provided=True,
     )
 
+    # Act
     result = task_service.patch_task(1, task_patch)
 
+    # Assert
     assert result is existing_task
     assert result.updated_at is None
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_not_called()
 
-def test_patch_task_raises_when_repository_returns_none(task_service: TaskService, repository: Mock) -> None:
+
+def test_patch_task_raises_and_rolls_back_when_repository_returns_none(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    patch_task should raise TaskNotFoundError and roll back when the task does not exist.
+    """
+    # Arrange
     repository.get_task.return_value = None
 
     task_patch = PatchTaskInput(
@@ -494,18 +594,27 @@ def test_patch_task_raises_when_repository_returns_none(task_service: TaskServic
         description_provided=True,
     )
 
+    # Act / Assert
     with pytest.raises(TaskNotFoundError, match="Task not found"):
         task_service.patch_task(999, task_patch)
 
     repository.get_task.assert_called_once_with(999)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()
 
-def test_patch_task_propagates_domain_error_and_does_not_save_when_final_state_is_invalid(
+
+def test_patch_task_propagates_domain_error_rolls_back_and_does_not_save_when_final_state_is_invalid(
     task_service: TaskService,
     repository: Mock,
+    uow: Mock,
 ) -> None:
+    """
+    patch_task should propagate domain validation errors, avoid saving,
+    and roll back the transaction.
+    """
+    # Arrange
     existing_task = build_new_task(
-        
         status=TaskStatus.PENDING,
         due_date=None,
         is_blocked=False,
@@ -517,8 +626,57 @@ def test_patch_task_propagates_domain_error_and_does_not_save_when_final_state_i
         status_provided=True,
     )
 
+    # Act / Assert
     with pytest.raises(InvalidTaskDueDateError, match="Due date is required for IN PROGRESS tasks"):
         task_service.patch_task(1, task_patch)
 
     repository.get_task.assert_called_once_with(1)
     repository.save_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()
+
+# ----------------------------------------
+# delete_task
+# ----------------------------------------
+
+def test_delete_task_calls_repository_delete_and_commits_when_task_exists(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    delete_task should call repository.delete_task and commit when the task exists.
+    """
+    # Arrange
+    existing_task = build_new_task(title="Task to delete")
+    repository.get_task.return_value = existing_task
+
+    # Act
+    task_service.delete_task(1)
+
+    # Assert
+    repository.get_task.assert_called_once_with(1)
+    repository.delete_task.assert_called_once_with(1)
+    uow.commit.assert_called_once()
+    uow.rollback.assert_not_called()
+
+
+def test_delete_task_raises_and_rolls_back_when_repository_returns_none(
+    task_service: TaskService,
+    repository: Mock,
+    uow: Mock,
+) -> None:
+    """
+    delete_task should raise TaskNotFoundError and roll back when the task does not exist.
+    """
+    # Arrange
+    repository.get_task.return_value = None
+
+    # Act / Assert
+    with pytest.raises(TaskNotFoundError, match="Task not found"):
+        task_service.delete_task(999)
+
+    repository.get_task.assert_called_once_with(999)
+    repository.delete_task.assert_not_called()
+    uow.commit.assert_not_called()
+    uow.rollback.assert_called_once()


### PR DESCRIPTION
# Epic

#4 EPIC-03 Persistence Layer

# User Story

Closes #14 US-08 Persist tasks in a database

## Overview

This PR introduces the first PostgreSQL-backed persistence flow for tasks using SQLAlchemy.

It replaces the previous in-memory-only persistence path with a real database-backed repository and aligns the application flow to work with explicit transaction handling.

## Changes

- add PostgreSQL and SQLAlchemy persistence foundation
- add application settings for database configuration
- add SQLAlchemy base and session factory
- add an initial manual schema bootstrap to support the first persistence flow
- add persistent TaskModel
- implement SqlAlchemyTaskRepository
- introduce SqlAlchemyUnitOfWork for explicit transaction handling
- update TaskService to use repository + unit of work
- update task dependency wiring to compose the service explicitly
- update integration test setup to build TaskService with repository + unit of work
- update unit and integration tests to support the persistence flow

## Architectural state

- routers continue to handle HTTP concerns only
- TaskService now orchestrates write use cases with explicit transaction boundaries
- repository remains focused on persistence and domain-to-model mapping
- SQLAlchemy concerns stay in infrastructure
- the application is now prepared for versioned schema evolution and future persistence extensions

### Scope notes

This PR uses an initial manual schema bootstrap to support the first persistence flow.

It does not include:

- Alembic migrations
- schema evolution/versioning
- task priority in the persistent model

These items will be handled in follow-up work under the remaining Epic-03 scope.

## Validation

- unit tests updated
- integration tests updated