### PR TITLE
EPIC-02 / fix - Reject blocked transition from PENDING to IN_PROGRESS

### DIFF
--- a/app/modules/tasks/domain/task.py
+++ b/app/modules/tasks/domain/task.py
@@ -143,8 +143,6 @@ class Task:
         target_status: TaskStatus,
         target_is_blocked: bool,
     ) -> None:
-        if not self.is_blocked:
-            return
 
         if self.status == TaskStatus.PENDING:
             if target_status == TaskStatus.IN_PROGRESS and target_is_blocked:

--- a/tests/unit/tasks/application/test_task_service.py
+++ b/tests/unit/tasks/application/test_task_service.py
@@ -266,7 +266,7 @@ def test_update_task_replaces_task_data_saves_it_and_commits(
         description="updated",
         status=TaskStatus.IN_PROGRESS,
         due_date=valid_due_date,
-        is_blocked=True,
+        is_blocked=False,
     )
 
     repository.save_task.side_effect = save_task_side_effect
@@ -280,7 +280,7 @@ def test_update_task_replaces_task_data_saves_it_and_commits(
     assert result.description == "updated"
     assert result.status == TaskStatus.IN_PROGRESS
     assert result.due_date == valid_due_date
-    assert result.is_blocked is True
+    assert result.is_blocked is False
     assert result.created_at == existing_task.created_at
     assert result.updated_at is not None
 

--- a/tests/unit/tasks/domain/test_task.py
+++ b/tests/unit/tasks/domain/test_task.py
@@ -234,7 +234,7 @@ def test_update_rejects_completed_with_blocked_true() -> None:
     # Act / Assert
     with pytest.raises(
         InvalidTaskStatusTransitionError,
-        match="Task can't be blocked in the COMPLETED state",
+        match="Can't change task status from IN PROGRESS to COMPLETED because the task is BLOCKED",
     ):
         task.update(
             title=task.title,
@@ -319,7 +319,7 @@ def test_update_does_not_mutate_task_when_validation_fails() -> None:
     # Act / Assert
     with pytest.raises(
         InvalidTaskStatusTransitionError,
-        match="Task can't be blocked in the COMPLETED state",
+        match="Can't change task status from IN PROGRESS to COMPLETED because the task is BLOCKED",
     ):
         task.update(
             title="Changed",
@@ -349,3 +349,105 @@ def test_mark_updated_sets_updated_at() -> None:
 
     # Assert
     assert task.updated_at == timestamp
+
+def test_update_rejects_transition_from_pending_to_in_progress_when_target_becomes_blocked() -> None:
+    """
+    update should reject the transition from PENDING to IN_PROGRESS
+    when the target state becomes blocked.
+    """
+    # Arrange
+    task = build_new_task(
+        status=TaskStatus.PENDING,
+        due_date=None,
+        is_blocked=False,
+    )
+
+    # Act / Assert
+    with pytest.raises(
+        InvalidTaskStatusTransitionError,
+        match="PENDING to IN PROGRESS",
+    ):
+        task.update(
+            title=task.title,
+            description=task.description,
+            status=TaskStatus.IN_PROGRESS,
+            due_date=future_date(),
+            is_blocked=True,
+        )
+
+def test_update_allows_transition_from_pending_to_in_progress_when_target_is_not_blocked() -> None:
+    """
+    update should allow the transition from PENDING to IN_PROGRESS
+    when the target state is not blocked.
+    """
+    # Arrange
+    task = build_new_task(
+        status=TaskStatus.PENDING,
+        due_date=None,
+        is_blocked=False,
+    )
+
+    # Act
+    changed = task.update(
+        title=task.title,
+        description=task.description,
+        status=TaskStatus.IN_PROGRESS,
+        due_date=future_date(),
+        is_blocked=False,
+    )
+
+    # Assert
+    assert changed is True
+    assert task.status == TaskStatus.IN_PROGRESS
+    assert task.is_blocked is False
+
+def test_update_rejects_transition_from_pending_blocked_to_in_progress_blocked() -> None:
+    """
+    update should reject the transition from PENDING to IN_PROGRESS
+    when the task remains blocked in the target state.
+    """
+    # Arrange
+    task = build_new_task(
+        status=TaskStatus.PENDING,
+        due_date=None,
+        is_blocked=True,
+    )
+
+    # Act / Assert
+    with pytest.raises(
+        InvalidTaskStatusTransitionError,
+        match="PENDING to IN PROGRESS",
+    ):
+        task.update(
+            title=task.title,
+            description=task.description,
+            status=TaskStatus.IN_PROGRESS,
+            due_date=future_date(),
+            is_blocked=True,
+        )
+
+def test_update_allows_transition_from_pending_blocked_to_in_progress_when_target_is_unblocked() -> None:
+    """
+    update should allow the transition from PENDING to IN_PROGRESS
+    when the target state is unblocked.
+    """
+    # Arrange
+    task = build_new_task(
+        status=TaskStatus.PENDING,
+        due_date=None,
+        is_blocked=True,
+    )
+
+    # Act
+    changed = task.update(
+        title=task.title,
+        description=task.description,
+        status=TaskStatus.IN_PROGRESS,
+        due_date=future_date(),
+        is_blocked=False,
+    )
+
+    # Assert
+    assert changed is True
+    assert task.status == TaskStatus.IN_PROGRESS
+    assert task.is_blocked is False


### PR DESCRIPTION
# Epic

#3 EPIC-02 Architecture Refactor

## Overview

This PR fixes a domain transition rule that incorrectly allowed a task to move from `PENDING` to `IN_PROGRESS` while ending the transition in a blocked state.

## Changes

- fix blocked transition validation in the Task domain entity
- reject `PENDING -> IN_PROGRESS` when the target state is blocked
- add domain tests to cover the invalid and valid transition combinations
- keep the rule enforced in the domain layer

## Architectural state

- the transition rule remains enforced in the Task domain entity
- service and repository layers continue to propagate domain behaviour without duplicating business rules
- domain tests now better protect combined status/blocking transition scenarios

## Validation

- unit tests updated
- domain rule reproduced with a failing test before the fix