### PR TITLE
refactor - Clarify service input and loaded task naming

### DIFF
--- a/app/modules/tasks/api/task_router.py
+++ b/app/modules/tasks/api/task_router.py
@@ -24,7 +24,7 @@ def get_task(task_id: int, task_service: TaskService = Depends(get_task_service)
 def create_task(payload: TaskInput, task_service: TaskService = Depends(get_task_service)):
     """Create a new task."""
     task_input = map_task_input(payload)
-    return task_service.create_task(task=task_input)
+    return task_service.create_task(task_input=task_input)
 
 
 @router.put("/tasks/{task_id}", response_model=TaskResponse, status_code=200)

--- a/app/modules/tasks/application/task_service.py
+++ b/app/modules/tasks/application/task_service.py
@@ -42,19 +42,19 @@ class TaskService:
         return self._repository.list_tasks()
 
 
-    def create_task(self, task: TaskInput) -> Task:
+    def create_task(self, task_input: TaskInput) -> Task:
         """Create a new task through the repository contract."""
         try:
-            task = Task.create(
-                title=task.title,
-                description=task.description,
-                status=task.status,
-                due_date=task.due_date,
-                is_blocked=task.is_blocked,
+            new_task = Task.create(
+                title=task_input.title,
+                description=task_input.description,
+                status=task_input.status,
+                due_date=task_input.due_date,
+                is_blocked=task_input.is_blocked,
                 created_at=self._current_timestamp()
             )
 
-            created_task = self._repository.create_task(task)
+            created_task = self._repository.create_task(new_task)
             self._uow.commit()
             return created_task
 
@@ -64,12 +64,12 @@ class TaskService:
 
     def get_task(self, task_id: int) -> Task:
         """Return a task by id or raise TaskNotFoundError if it does not exist."""
-        task = self._repository.get_task(task_id)
+        current_task = self._repository.get_task(task_id)
 
-        if task is None:
+        if current_task is None:
             raise TaskNotFoundError("Task not found")
 
-        return task
+        return current_task
 
     def update_task(self, task_id: int, task_input: TaskInput) -> Task:
         """Fully replace task data using the provided application input."""


### PR DESCRIPTION
Overview

This PR refactors naming in the task service for better clarity and updates the router to match the new service signature.

Changes

- rename `task` to `task_input` in `create_task()`

- rename the created domain entity variable to `new_task`

- rename the loaded task variable to `current_task`

- align the router call with the updated service parameter name