### PR TITLE
refactor - Inline task input mapping for create and update

### DIFF
--- a/app/modules/tasks/api/task_router.py
+++ b/app/modules/tasks/api/task_router.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends
 
-from app.modules.tasks.api.task_schemas import TaskInput, TaskPatch, TaskResponse
+from app.modules.tasks.api.task_schemas import TaskPatch, TaskResponse, TaskInput as TaskInputSchema
+from app.modules.tasks.application.task_dtos import TaskInput as TaskInputDTO
 from app.modules.tasks.application.task_service import TaskService
-from app.modules.tasks.application.task_mappers import map_task_input, map_task_patch_to_input
+from app.modules.tasks.application.task_mappers import map_task_patch_to_input
 from app.modules.tasks.api.dependencies import get_task_service
 
 router = APIRouter()
@@ -21,16 +22,28 @@ def get_task(task_id: int, task_service: TaskService = Depends(get_task_service)
 
 
 @router.post("/tasks", response_model=TaskResponse, status_code=201)
-def create_task(payload: TaskInput, task_service: TaskService = Depends(get_task_service)):
+def create_task(payload: TaskInputSchema, task_service: TaskService = Depends(get_task_service)):
     """Create a new task."""
-    task_input = map_task_input(payload)
+    task_input = TaskInputDTO(
+        title=payload.title,
+        description=payload.description,
+        status=payload.status,
+        due_date=payload.due_date,
+        is_blocked=payload.is_blocked
+    )
     return task_service.create_task(task_input=task_input)
 
 
 @router.put("/tasks/{task_id}", response_model=TaskResponse, status_code=200)
-def update_task(task_id: int, payload: TaskInput, task_service: TaskService = Depends(get_task_service)):
+def update_task(task_id: int, payload: TaskInputSchema, task_service: TaskService = Depends(get_task_service)):
     """Fully replace task data."""
-    task_input = map_task_input(payload)
+    task_input = TaskInputDTO(
+        title=payload.title,
+        description=payload.description,
+        status=payload.status,
+        due_date=payload.due_date,
+        is_blocked=payload.is_blocked
+    )
     return task_service.update_task(task_id=task_id, task_input=task_input)
 
 

--- a/app/modules/tasks/application/task_mappers.py
+++ b/app/modules/tasks/application/task_mappers.py
@@ -1,15 +1,5 @@
-from app.modules.tasks.application.task_dtos import PatchTaskInput, TaskInput as TaskInputDTO
-from app.modules.tasks.api.task_schemas import TaskPatch, TaskInput as TaskInputSchema
-
-
-def map_task_input(task_input: TaskInputSchema) -> TaskInputDTO:
-    return TaskInputDTO(
-        title=task_input.title,
-        description=task_input.description,
-        status=task_input.status,
-        due_date=task_input.due_date,
-        is_blocked=task_input.is_blocked
-    )
+from app.modules.tasks.application.task_dtos import PatchTaskInput
+from app.modules.tasks.api.task_schemas import TaskPatch
 
 
 def map_task_patch_to_input(task_patch: TaskPatch) -> PatchTaskInput:

--- a/app/modules/tasks/application/task_service.py
+++ b/app/modules/tasks/application/task_service.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from app.modules.tasks.application.task_dtos import TaskInput, PatchTaskInput
+from app.modules.tasks.application.task_dtos import TaskInput as TaskInputDTO, PatchTaskInput as PatchTaskInputDTO
 from app.modules.tasks.application.task_repository import TaskRepository
 from app.application.unit_of_work import UnitOfWork
 from app.modules.tasks.domain.task import Task
@@ -19,7 +19,7 @@ class TaskService:
         """Return the current UTC timestamp without microseconds."""
         return datetime.now(UTC).replace(microsecond=0)
 
-    def _apply_update(self, task: Task, task_input: TaskInput) -> tuple[Task, bool]:
+    def _apply_update(self, task: Task, task_input: TaskInputDTO) -> tuple[Task, bool]:
         """Apply a full update to an existing task and persist it if changed."""
         changed = task.update(
             title=task_input.title,
@@ -42,7 +42,7 @@ class TaskService:
         return self._repository.list_tasks()
 
 
-    def create_task(self, task_input: TaskInput) -> Task:
+    def create_task(self, task_input: TaskInputDTO) -> Task:
         """Create a new task through the repository contract."""
         try:
             new_task = Task.create(
@@ -71,7 +71,7 @@ class TaskService:
 
         return current_task
 
-    def update_task(self, task_id: int, task_input: TaskInput) -> Task:
+    def update_task(self, task_id: int, task_input: TaskInputDTO) -> Task:
         """Fully replace task data using the provided application input."""
         try:
             current_task = self.get_task(task_id)
@@ -86,12 +86,12 @@ class TaskService:
             self._uow.rollback()
             raise
 
-    def patch_task(self, task_id: int, task_input: PatchTaskInput) -> Task:
+    def patch_task(self, task_id: int, task_input: PatchTaskInputDTO) -> Task:
         """Partially update task data using the provided application input."""
         try:
             current_task = self.get_task(task_id)
 
-            full_input = TaskInput(
+            full_input = TaskInputDTO(
                 title=task_input.title if task_input.title_provided else current_task.title,
                 description=task_input.description if task_input.description_provided else current_task.description,
                 status=task_input.status if task_input.status_provided else current_task.status,


### PR DESCRIPTION
Overview

This PR simplifies the router-to-service input flow for create and full update operations.

Changes

- remove `map_task_input()` from the application mapper module
- build `TaskInput` directly in the router for `POST /tasks`
- build `TaskInput` directly in the router for `PUT /tasks/{id}`
- keep patch mapping separate because partial update semantics still require dedicated handling
- clarify DTO naming in the service layer

Why

The previous `map_task_input()` function was a simple field-to-field pass-through and did not add meaningful transformation logic.

Inlining this mapping in the router makes the flow more explicit while keeping PATCH as a separate case.